### PR TITLE
Ensure FKs from other tables are updated on swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # pg-online-schema-change
 
-pg-online-schema-change is a tool for making schema changes in Postgres tables with minimal locks, thus helping achieve zero down time schema changes against production workloads. 
+pg-online-schema-change is a tool for making schema changes (any `ALTER` statements) in Postgres tables with minimal locks, thus helping achieve zero down time schema changes against production workloads. 
 
-pg-online-schema-change is inspired from the design and workings of tools like `pg_repack` and `pt-online-schema-change` for MySQL. Read more [below](#how-does-it-work) on how it works in action.
+pg-online-schema-change is inspired from the design and workings of tools like `pg_repack` and `pt-online-schema-change` for MySQL. Read more [below](#how-does-it-work) on how it works in action, features and any caveats.
 
 ⚠️ ⚠️ THIS IS CURRENTLY WIP AND IS CONSIDERED EXPERIMENTAL ⚠️ ⚠️ 
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -51,35 +52,44 @@ Usage:
 
 print the version
 ```
-
-## Caveats / Limitations
-- A primary key should exists on the table, without it pgosc will error out early.
-  - This is because - currently there is no other way to uniquely identify rows during replay.
-- For a brief moment, towards the end of the process pgosc will acquire a `ACCESS EXCLUSIVE lock` to perform the swap of table name and FK references
-- By design it doesn't kill any other DDLs being performed. Its best to not run any DDLs against parent table during the process to avoid any issues.
-- During the nature of duplicating a table, there needs to be enough space on the disk to support the operation.
-- Index, constraints and sequence names will be altered and lose their original naming (can be fixed in future releases).
-- Triggers are not carried over. 
-- Foreign keys are dropped & re-added to referencing tables with a NOT VALID.
-  - This is to ensure that integrity is maintained as before but skip the FK validation to avoid long locks.
 ## How does it work
 
 - Primary table: A table against which a potential schema change is to be run
 - Shadow table: A copy of an existing primary table
 - Audit table: A table to store any updates/inserts/delete on a primary table
 
-1. Create an audit table to record changes made to the parent table
-2. Add a trigger on the parent table (for inserts, updates, deletes) to our audit table
-3. Create new shadow table with all rows from old table. 
+1. Create an audit table to record changes made to the parent table.
+2. Add a trigger on the parent table (for inserts, updates, deletes) to our audit table.
+3. Create new shadow table with all rows from old table.
 4. Run ALTER/migration on the shadow table.
 5. Build indexes on the new table.
-6. Replay all changes accumulated in the audit table against the shadow table
-   - Delete rows in audit table as they are replayed
+6. Replay all changes accumulated in the audit table against the shadow table.
+   - Delete rows in audit table as they are replayed.
 7. Once the delta (reamaining rows) is ~20 rows, acquire an access exclusive lock against the parent table, within a transaction and:
-   - swap table names (shadow table <> parent table)
-   - update references in other tables (FKs) by dropping and re-creating the FKs with a `NOT VALID`
-8. Drop parent (now old) table (OPTIONAL)
+   - swap table names (shadow table <> parent table).
+   - update references in other tables (FKs) by dropping and re-creating the FKs with a `NOT VALID`.
+8. Runs `ANALYZE` on the new table.
+9. Drop parent (now old) table (OPTIONAL).
 
+### Prominent features
+- It supports when a column is being added, dropped or renamed with no data loss. 
+- It acquires minimal locks through out the process (read more below on the caveat).
+- Copies over indexes and Foreign keys.
+- Optionally drop or retain old tables in the end.
+- **TBD**: It supports the ability to reverse the change with no data loss. pgosc makes sure that the data is being replayed in both directions (tables) before and after the swap. So in case of any issues, you can always go back to the original table.
+
+### Caveats / Limitations
+- A primary key should exists on the table, without it pgosc will error out early.
+  - This is because - currently there is no other way to uniquely identify rows during replay.
+- For a brief moment, towards the end of the process pgosc will acquire a `ACCESS EXCLUSIVE lock` to perform the swap of table name and FK references.
+- By design it doesn't kill any other DDLs being performed. Its best to not run any DDLs against parent table during the process to avoid any issues.
+- During the nature of duplicating a table, there needs to be enough space on the disk to support the operation.
+- Index, constraints and sequence names will be altered and lose their original naming.
+  - Can be fixed in future releases. Feel free to open a feature req.
+- Triggers are not carried over. 
+  - Can be fixed in future releases. Feel free to open a feature req.
+- Foreign keys are dropped & re-added to referencing tables with a NOT VALID.
+  - This is to ensure that integrity is maintained as before but skip the FK validation to avoid long locks.
 ## Development
 
 - Install ruby 3.0

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ print the version
 - During the nature of duplicating a table, there needs to be enough space on the disk to support the operation.
 - Index, constraints and sequence names will be altered and lose their original naming (can be fixed in future releases).
 - Triggers are not carried over. 
-
+- Foreign keys are dropped & re-added to referencing tables with a NOT VALID.
+  - This is to ensure that integrity is maintained as before but skip the FK validation to avoid long locks.
 ## How does it work
 
 - Primary table: A table against which a potential schema change is to be run

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -242,11 +242,13 @@ module PgOnlineSchemaChange
 
       def swap!
         @old_primary_table = "pgosc_old_primary_table_#{client.table}"
+        foreign_key_statements = Query.get_foreign_keys_to_refresh(client, client.table)
 
         sql = <<~SQL
           LOCK TABLE #{client.table} IN ACCESS EXCLUSIVE MODE;
           ALTER TABLE #{client.table} RENAME to #{old_primary_table};
           ALTER TABLE #{shadow_table} RENAME to #{client.table};
+          #{foreign_key_statements}
         SQL
 
         Query.run(client.connection, sql)

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -75,7 +75,7 @@ module PgOnlineSchemaChange
         indexes
       end
 
-      def get_all_constraints_for(client, table)
+      def get_all_constraints_for(client)
         query = <<~SQL
           SELECT  conrelid::regclass AS table_on,
                   confrelid::regclass AS table_from,
@@ -83,7 +83,7 @@ module PgOnlineSchemaChange
                   conname AS constraint_name,
                   pg_get_constraintdef(oid) AS definition
           FROM   	pg_constraint
-          WHERE  	contype IN ('f', 'p') AND conrelid::regclass = \'#{table}\'::regclass
+          WHERE  	contype IN ('f', 'p')
         SQL
 
         constraints = []
@@ -95,13 +95,13 @@ module PgOnlineSchemaChange
       end
 
       def get_primary_keys_for(client, table)
-        get_all_constraints_for(client, table).select do |row|
+        get_all_constraints_for(client).select do |row|
           row["table_on"] == table && row["constraint_type"] == "p"
         end
       end
 
       def get_foreign_keys_for(client, table)
-        get_all_constraints_for(client, table).select do |row|
+        get_all_constraints_for(client).select do |row|
           row["table_on"] == table && row["constraint_type"] == "f"
         end
       end

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -106,7 +106,7 @@ module PgOnlineSchemaChange
         end
       end
 
-      def get_foreign_keys_to_add(client, table)
+      def get_foreign_keys_to_refresh(client, table)
         references = get_all_constraints_for(client).select do |row|
           row["table_from"] == table && row["constraint_type"] == "f"
         end

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -1130,9 +1130,9 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
       foreign_keys = PgOnlineSchemaChange::Query.get_foreign_keys_for(client, "chapters")
       expect(foreign_keys).to eq([
-                                { "table_on" => "chapters", "table_from" => "books",
-                                  "constraint_type" => "f", "constraint_name" => "chapters_book_id_fkey", "definition" => "FOREIGN KEY (book_id) REFERENCES books(user_id" },
-                              ])
+                                   { "table_on" => "chapters", "table_from" => "books",
+                                     "constraint_type" => "f", "constraint_name" => "chapters_book_id_fkey", "definition" => "FOREIGN KEY (book_id) REFERENCES books(user_id" },
+                                 ])
     end
   end
 end

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -1126,13 +1126,25 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
     end
 
     it "sucessfully renames the tables and transfers foreign keys" do
+      result = [
+        { "table_on" => "chapters", "table_from" => "books",
+          "constraint_type" => "f", "constraint_name" => "chapters_book_id_fkey", "definition" => "FOREIGN KEY (book_id) REFERENCES books(user_id)" },
+      ]
+
+      # before (w/o not valid)
+      foreign_keys = PgOnlineSchemaChange::Query.get_foreign_keys_for(client, "chapters")
+      expect(foreign_keys).to eq(result)
+
       described_class.swap!
 
+      result = [
+        { "table_on" => "chapters", "table_from" => "books",
+          "constraint_type" => "f", "constraint_name" => "chapters_book_id_fkey", "definition" => "FOREIGN KEY (book_id) REFERENCES books(user_id) NOT VALID" },
+      ]
+
+      # before (w/ not valid)
       foreign_keys = PgOnlineSchemaChange::Query.get_foreign_keys_for(client, "chapters")
-      expect(foreign_keys).to eq([
-                                   { "table_on" => "chapters", "table_from" => "books",
-                                     "constraint_type" => "f", "constraint_name" => "chapters_book_id_fkey", "definition" => "FOREIGN KEY (book_id) REFERENCES books(user_id" },
-                                 ])
+      expect(foreign_keys).to eq(result)
     end
   end
 end

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -1125,7 +1125,14 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
                              "CREATE UNIQUE INDEX pgosc_shadow_table_for_books_email_key ON books USING btree (email)"])
     end
 
-    skip "sucessfully renames the tables and transfers foreign keys" do
+    it "sucessfully renames the tables and transfers foreign keys" do
+      described_class.swap!
+
+      foreign_keys = PgOnlineSchemaChange::Query.get_foreign_keys_for(client, "chapters")
+      expect(foreign_keys).to eq([
+                                { "table_on" => "chapters", "table_from" => "books",
+                                  "constraint_type" => "f", "constraint_name" => "chapters_book_id_fkey", "definition" => "FOREIGN KEY (book_id) REFERENCES books(user_id" },
+                              ])
     end
   end
 end

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -91,12 +91,18 @@ RSpec.describe PgOnlineSchemaChange::Query do
 
     it "returns all constraints" do
       result = [
+        { "table_on" => "sellers", "table_from" => "-", "constraint_type" => "p", "constraint_name" => "sellers_pkey",
+          "definition" => "PRIMARY KEY (id)" },
         { "table_on" => "books", "table_from" => "-", "constraint_type" => "p", "constraint_name" => "books_pkey",
           "definition" => "PRIMARY KEY (user_id)" },
         { "table_on" => "books", "table_from" => "sellers", "constraint_type" => "f",
           "constraint_name" => "books_seller_id_fkey", "definition" => "FOREIGN KEY (seller_id) REFERENCES sellers(id)" },
+        { "table_on" => "chapters", "table_from" => "-", "constraint_type" => "p",
+          "constraint_name" => "chapters_pkey", "definition" => "PRIMARY KEY (id)" },
+        { "table_on" => "chapters", "table_from" => "books", "constraint_type" => "f",
+          "constraint_name" => "chapters_book_id_fkey", "definition" => "FOREIGN KEY (book_id) REFERENCES books(user_id)" },
       ]
-      expect(described_class.get_all_constraints_for(client, "books")).to eq(result)
+      expect(described_class.get_all_constraints_for(client)).to eq(result)
     end
   end
 

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe PgOnlineSchemaChange::Query do
     end
   end
 
-  describe ".get_foreign_keys_to_add" do
+  describe ".get_foreign_keys_to_refresh" do
     let(:client) { PgOnlineSchemaChange::Client.new(client_options) }
 
     before do
@@ -147,7 +147,7 @@ RSpec.describe PgOnlineSchemaChange::Query do
 
     it "returns drop and add statements" do
       result = "ALTER TABLE public.chapters DROP CONSTRAINT chapters_book_id_fkey; ALTER TABLE public.chapters ADD CONSTRAINT chapters_book_id_fkey FOREIGN KEY (book_id) REFERENCES books(user_id) NOT VALID;"
-      expect(described_class.get_foreign_keys_to_add(client, "books")).to eq(result)
+      expect(described_class.get_foreign_keys_to_refresh(client, "books")).to eq(result)
     end
 
     it "returns drop and add statements accordingly when NOT NULL is present" do
@@ -157,7 +157,7 @@ RSpec.describe PgOnlineSchemaChange::Query do
                           " ALTER TABLE public.chapters ADD CONSTRAINT chapters_book_id_fkey FOREIGN KEY (book_id) REFERENCES books(user_id) NOT VALID;")
 
       result = "ALTER TABLE public.chapters DROP CONSTRAINT chapters_book_id_fkey; ALTER TABLE public.chapters ADD CONSTRAINT chapters_book_id_fkey FOREIGN KEY (book_id) REFERENCES books(user_id) NOT VALID;"
-      expect(described_class.get_foreign_keys_to_add(client, "books")).to eq(result)
+      expect(described_class.get_foreign_keys_to_refresh(client, "books")).to eq(result)
     end
   end
 

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -138,6 +138,29 @@ RSpec.describe PgOnlineSchemaChange::Query do
     end
   end
 
+  describe ".get_foreign_keys_to_add" do
+    let(:client) { PgOnlineSchemaChange::Client.new(client_options) }
+
+    before do
+      setup_tables(client)
+    end
+
+    it "returns drop and add statements" do
+      result = "ALTER TABLE public.chapters DROP CONSTRAINT chapters_book_id_fkey; ALTER TABLE public.chapters ADD CONSTRAINT chapters_book_id_fkey FOREIGN KEY (book_id) REFERENCES books(user_id) NOT VALID;"
+      expect(described_class.get_foreign_keys_to_add(client, "books")).to eq(result)
+    end
+
+    it "returns drop and add statements accordingly when NOT NULL is present" do
+      client = PgOnlineSchemaChange::Client.new(client_options)
+      described_class.run(client.connection, "ALTER TABLE public.chapters DROP CONSTRAINT chapters_book_id_fkey;")
+      described_class.run(client.connection,
+                          " ALTER TABLE public.chapters ADD CONSTRAINT chapters_book_id_fkey FOREIGN KEY (book_id) REFERENCES books(user_id) NOT VALID;")
+
+      result = "ALTER TABLE public.chapters DROP CONSTRAINT chapters_book_id_fkey; ALTER TABLE public.chapters ADD CONSTRAINT chapters_book_id_fkey FOREIGN KEY (book_id) REFERENCES books(user_id) NOT VALID;"
+      expect(described_class.get_foreign_keys_to_add(client, "books")).to eq(result)
+    end
+  end
+
   describe ".alter_statement_for" do
     it "returns alter statement for shadow table" do
       client = PgOnlineSchemaChange::Client.new(client_options)


### PR DESCRIPTION
This ensures that FKs on other tables that point to the primary table that is being
altered, continue pointing to the same table after rename swap. When swap happens, 
a.k.a rename. The FKs on other tables will point to the table renamed table (old one). 

Consider this: 
Primary table: `books`
Table with FK pointing to books: `chapters`

after swap we have three tables
- `books`
- `chapters`
- `pgosc_old_primary_table_books`

However, the FK on `chapters` (`book_id`) is now pointing to `pgosc_old_primary_table_books`, instead of `books`. 

This PR fixes that by dropping those FKs (in the same transaction as swap) then adds them back again on the new table, after the rename.   