### PR TITLE
Support for transaction, rollbacks and moving to async_exec 

### DIFF
--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -31,7 +31,9 @@ module PgOnlineSchemaChange
       rescue Exception
         connection.cancel if connection.transaction_status != PG::PQTRANS_IDLE
         connection.block
+        PgOnlineSchemaChange.logger.info("Exception raised, rolling back query", { rollback: true, query: query })
         connection.async_exec("ROLLBACK;")
+        connection.async_exec("COMMIT;")
         raise
       else
         connection.async_exec("COMMIT;")

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe PgOnlineSchemaChange::Query do
       client = PgOnlineSchemaChange::Client.new(client_options)
       query = "SELECT 'FooBar' as result"
 
-      expect(client.connection).to receive(:exec).with("BEGIN;").and_call_original
-      expect(client.connection).to receive(:exec).with("SELECT 'FooBar' as result").and_call_original
-      expect(client.connection).to receive(:exec).with("COMMIT;").and_call_original
+      expect(client.connection).to receive(:async_exec).with("BEGIN;").and_call_original
+      expect(client.connection).to receive(:async_exec).with("SELECT 'FooBar' as result").and_call_original
+      expect(client.connection).to receive(:async_exec).with("COMMIT;").and_call_original
 
       described_class.run(client.connection, query) do |result|
         expect(result.count).to eq(1)
@@ -218,9 +218,9 @@ RSpec.describe PgOnlineSchemaChange::Query do
         WHERE schemaname = 'public' AND tablename = 'books'
       SQL
 
-      expect(client.connection).to receive(:exec).with("BEGIN;").and_call_original
-      expect(client.connection).to receive(:exec).with(query).and_call_original
-      expect(client.connection).to receive(:exec).with("COMMIT;").and_call_original
+      expect(client.connection).to receive(:async_exec).with("BEGIN;").and_call_original
+      expect(client.connection).to receive(:async_exec).with(query).and_call_original
+      expect(client.connection).to receive(:async_exec).with("COMMIT;").and_call_original
 
       result = described_class.get_indexes_for(client, "books")
       expect(result).to eq([
@@ -253,9 +253,9 @@ RSpec.describe PgOnlineSchemaChange::Query do
         AND indisprimary
       SQL
 
-      expect(client.connection).to receive(:exec).with("BEGIN;").and_call_original
-      expect(client.connection).to receive(:exec).with(query).and_call_original
-      expect(client.connection).to receive(:exec).with("COMMIT;").and_call_original
+      expect(client.connection).to receive(:async_exec).with("BEGIN;").and_call_original
+      expect(client.connection).to receive(:async_exec).with(query).and_call_original
+      expect(client.connection).to receive(:async_exec).with("COMMIT;").and_call_original
 
       result = described_class.primary_key_for(client, client.table)
       expect(result).to eq("user_id")


### PR DESCRIPTION
We were doing begin/commit but this now performs
a rollback on any exception raises. Similar to
PG::Connection#transaction. However, this is easier
to test

`async_exec` is an alias to `exec`, just being explicit

- [x] spec for rollback