### PR TITLE
Run ANALYZE post COPY and ALTER statements

### DIFF
--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -38,6 +38,7 @@ module PgOnlineSchemaChange
         disable_vacuum!
         copy_data!
         run_alter_statement!
+        run_analyze!
         replay_and_swap!
         run_analyze!
         # drop_and_cleanup!


### PR DESCRIPTION
Since we are copying the data onto a fresh new table,
that looks (structurally) like the original table, its
better to run ANALYZE so planners are up to date.

We do it once after swap, just as good measure, also in case
the duration to replay change is long (true, when working with large
tables and copying a table can take hours, while changes are being accumulated
in the audit table)

cc @jfrost
https://github.com/shayonj/pg-online-schema-change/pull/6#issuecomment-1025198001