### PR TITLE
Support to perform operations in any schema

### DIFF
--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -19,6 +19,7 @@ module PgOnlineSchemaChange
         sql = <<~SQL
           SET statement_timeout = 0;
           SET client_min_messages = warning;
+          SET search_path TO #{client.schema};
         SQL
 
         Query.run(client.connection, sql)

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -122,12 +122,12 @@ module PgOnlineSchemaChange
 
         references.map do |row|
           if row["definition"].end_with?("NOT VALID")
-            add_statement = "ALTER TABLE #{client.schema}.#{row["table_on"]} ADD CONSTRAINT #{row["constraint_name"]} #{row["definition"]};"
+            add_statement = "ALTER TABLE #{row["table_on"]} ADD CONSTRAINT #{row["constraint_name"]} #{row["definition"]};"
           else
-            add_statement = "ALTER TABLE #{client.schema}.#{row["table_on"]} ADD CONSTRAINT #{row["constraint_name"]} #{row["definition"]} NOT VALID;"
+            add_statement = "ALTER TABLE #{row["table_on"]} ADD CONSTRAINT #{row["constraint_name"]} #{row["definition"]} NOT VALID;"
           end
 
-          drop_statement = "ALTER TABLE #{client.schema}.#{row["table_on"]} DROP CONSTRAINT #{row["constraint_name"]};"
+          drop_statement = "ALTER TABLE #{row["table_on"]} DROP CONSTRAINT #{row["constraint_name"]};"
 
           "#{drop_statement} #{add_statement}"
         end.join

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PgOnlineSchemaChange::Client do
     expect(client.host).to eq("127.0.0.1")
     expect(client.password).to eq("password")
     expect(client.alter_statement).to eq("ALTER TABLE books ADD COLUMN \"purchased\" BOOLEAN DEFAULT FALSE;")
-    expect(client.schema).to eq("public")
+    expect(client.schema).to eq("test_schema")
     expect(client.dbname).to eq("postgres")
     expect(client.username).to eq("jamesbond")
     expect(client.port).to eq(5432)

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -3,12 +3,19 @@
 require "pry"
 RSpec.describe PgOnlineSchemaChange::Orchestrate do
   describe ".setup!" do
+    let(:client) { PgOnlineSchemaChange::Client.new(client_options) }
+
+    before do
+      allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
+      setup_tables(client)
+    end
+
     it "sets the defaults & functions" do
       client = PgOnlineSchemaChange::Client.new(client_options)
       expect(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
 
       expect(client.connection).to receive(:async_exec).with("BEGIN;").exactly(5).times.and_call_original
-      expect(client.connection).to receive(:async_exec).with("SET statement_timeout = 0;\nSET client_min_messages = warning;\n").and_call_original
+      expect(client.connection).to receive(:async_exec).with("SET statement_timeout = 0;\nSET client_min_messages = warning;\nSET search_path TO #{client.schema};\n").and_call_original
       expect(client.connection).to receive(:async_exec).with(FUNC_FIX_SERIAL_SEQUENCE).and_call_original
       expect(client.connection).to receive(:async_exec).with(FUNC_CREATE_TABLE_ALL).and_call_original
       expect(client.connection).to receive(:async_exec).with("COMMIT;").exactly(5).times.and_call_original
@@ -36,7 +43,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         SELECT routine_name
         FROM information_schema.routines
         WHERE routine_type='FUNCTION'
-          AND specific_schema='public'
+          AND specific_schema=\'#{client.schema}\'
           AND routine_name='fix_serial_sequence';
       SQL
       rows = []
@@ -99,9 +106,8 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
     before do
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
-      described_class.setup!(client_options)
-
       setup_tables(client)
+      described_class.setup!(client_options)
 
       described_class.setup_audit_table!
     end
@@ -241,9 +247,8 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
     before do
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
-      described_class.setup!(client_options)
-
       setup_tables(client)
+      described_class.setup!(client_options)
     end
 
     after do
@@ -317,9 +322,8 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
     before do
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
-      described_class.setup!(client_options)
-
       setup_tables(client)
+      described_class.setup!(client_options)
 
       described_class.setup_audit_table!
       described_class.setup_shadow_table!
@@ -367,9 +371,9 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
     before do
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
+      setup_tables(client)
       described_class.setup!(client_options)
 
-      setup_tables(client)
       ingest_dummy_data_into_dummy_table(client)
 
       described_class.setup_shadow_table!
@@ -420,9 +424,8 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
     before do
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
-      described_class.setup!(client_options)
-
       setup_tables(client)
+      described_class.setup!(client_options)
 
       described_class.setup_audit_table!
       described_class.setup_shadow_table!
@@ -470,10 +473,10 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
       before do
         allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
-        described_class.setup!(client_options)
-
         cleanup_dummy_tables(client)
         create_dummy_tables(client)
+
+        described_class.setup!(client_options)
 
         described_class.setup_audit_table!
         described_class.setup_shadow_table!
@@ -518,9 +521,8 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
       before do
         allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
-        described_class.setup!(client_options)
-
         setup_tables(client)
+        described_class.setup!(client_options)
 
         described_class.setup_audit_table!
         described_class.setup_shadow_table!
@@ -568,9 +570,9 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
       before do
         allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
+        setup_tables(client)
         described_class.setup!(client_options)
 
-        setup_tables(client)
         ingest_dummy_data_into_dummy_table(client)
 
         described_class.setup_audit_table!
@@ -765,9 +767,9 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
       before do
         allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
+        setup_tables(client)
         described_class.setup!(client_options)
 
-        setup_tables(client)
         ingest_dummy_data_into_dummy_table(client)
 
         described_class.setup_audit_table!
@@ -908,9 +910,9 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
       before do
         allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
+        setup_tables(client)
         described_class.setup!(client_options)
 
-        setup_tables(client)
         ingest_dummy_data_into_dummy_table(client)
 
         described_class.setup_audit_table!
@@ -1051,9 +1053,9 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
     before do
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
+      setup_tables(client)
       described_class.setup!(client_options)
 
-      setup_tables(client)
       ingest_dummy_data_into_dummy_table(client)
 
       described_class.setup_audit_table!
@@ -1133,9 +1135,9 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
     before do
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
+      setup_tables(client)
       described_class.setup!(client_options)
 
-      setup_tables(client)
       ingest_dummy_data_into_dummy_table(client)
 
       described_class.setup_audit_table!

--- a/todo
+++ b/todo
@@ -1,4 +1,3 @@
-# TODO: add client.schema to all queries. everything assumes its in the public schema
 # TODO: support dry run mode
 # TODO: Potential to refactor Orchestrator class and extract some functions into a utility/helper class
 # TODO: Refactor class level vars on Orchestrate. Might need some form of "Store".


### PR DESCRIPTION
We were taking in schema as the input
but majority of the code written just
assumed public. This now sets the
search_path to the schema before performing
any operations.

Tweaks to specs and spec helpers to respect
the new settings and setting the search_path
accordingly in testing environment too