### PR TITLE
Ensure all alter statements belong to the same table

### DIFF
--- a/lib/pg_online_schema_change/client.rb
+++ b/lib/pg_online_schema_change/client.rb
@@ -23,6 +23,10 @@ module PgOnlineSchemaChange
 
       raise Error, "Not a valid ALTER statement: #{@alter_statement}" unless Query.alter_statement?(@alter_statement)
 
+      unless Query.same_table?(@alter_statement)
+        raise Error "All statements should belong to the same table: #{@alter_statement}"
+      end
+
       @table = Query.table(@alter_statement)
 
       PgOnlineSchemaChange.logger.debug("Connection established")

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -16,6 +16,20 @@ module PgOnlineSchemaChange
         false
       end
 
+      def same_table?(query)
+        tables = PgQuery.parse(query).tree.stmts.map do |statement|
+          if statement.stmt.alter_table_stmt.instance_of?(PgQuery::AlterTableStmt)
+            statement.stmt.alter_table_stmt.relation.relname
+          elsif statement.stmt.rename_stmt.instance_of?(PgQuery::RenameStmt)
+            statement.stmt.rename_stmt.relation.relname
+          end
+        end.compact
+
+        tables.uniq.count == 1
+      rescue PgQuery::ParseError => e
+        false
+      end
+
       def table(query)
         from_rename_statement = PgQuery.parse(query).tree.stmts.map do |statement|
           statement.stmt.rename_stmt&.relation&.relname

--- a/todo
+++ b/todo
@@ -3,7 +3,6 @@
 # TODO: Refactor class level vars on Orchestrate. Might need some form of "Store".
 # TODO: Refactor specs. Most are behaving as integration specs. Separate into unit/ and integration/ for starters.
 # TODO: Release process - gem and dockerfile
-# TODO: Ensure all alter statement(s) belong to the same table
 # TODO: BEGIN ISOLATION LEVEL SERIALIZABLE for copying rows
 # TODO: SUPPORT TABLE RENAME?
 # TODO: REMOVE _pgsoc suffixes from index name and restore them to their original name


### PR DESCRIPTION
The design is centered around `client.table`, hence this validation check. Multiple invocations of pgosc is also possible if there is a need to run alter statements against different tables. pgosc supports multiple `ALTER` statements in a single invocation.  