### PR TITLE
Restore storage parameters post swap & drop+cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
     $ gem install pg_online_schema_change
 
 ## Requirements
-- PostgreSQL 9.3 and later
+- PostgreSQL 9.6 and later
 - Ruby 2.6 and later
 - Database user should have permissions for `TRIGGER` and/or a `SUPERUSER`
 

--- a/lib/pg_online_schema_change/cli.rb
+++ b/lib/pg_online_schema_change/cli.rb
@@ -13,6 +13,8 @@ module PgOnlineSchemaChange
     method_option :port, aliases: "-p", type: :numeric, required: true, default: 5432, desc: "Port for the Database"
     method_option :password, aliases: "-w", type: :string, required: true, desc: "Password for the Database"
     method_option :verbose, aliases: "-v", type: :boolean, default: false, desc: "Emit logs in debug mode"
+    method_option :drop, aliases: "-f", type: :boolean, default: false,
+                         desc: "Drop the original table in the end after the swap"
 
     def perform
       client_options = Struct.new(*options.keys.map(&:to_sym)).new(*options.values)

--- a/lib/pg_online_schema_change/client.rb
+++ b/lib/pg_online_schema_change/client.rb
@@ -2,7 +2,7 @@ require "pg"
 
 module PgOnlineSchemaChange
   class Client
-    attr_accessor :alter_statement, :schema, :dbname, :host, :username, :port, :password, :connection, :table
+    attr_accessor :alter_statement, :schema, :dbname, :host, :username, :port, :password, :connection, :table, :drop
 
     def initialize(options)
       @alter_statement = options.alter_statement
@@ -12,6 +12,7 @@ module PgOnlineSchemaChange
       @username = options.username
       @port = options.port
       @password = options.password
+      @drop = options.drop
 
       @connection = PG.connect(
         dbname: @dbname,

--- a/lib/pg_online_schema_change/functions.rb
+++ b/lib/pg_online_schema_change/functions.rb
@@ -1,28 +1,28 @@
 FUNC_FIX_SERIAL_SEQUENCE = <<~SQL.freeze
-  CREATE OR REPLACE FUNCTION fix_serial_sequence(_table regclass, _newtable text)
-  RETURNS void AS
-  $func$
-  DECLARE
-  _sql text;
-  BEGIN
+    CREATE OR REPLACE FUNCTION fix_serial_sequence(_table regclass, _newtable text)
+    RETURNS void AS
+    $func$
+    DECLARE
+    _sql text;
+    BEGIN
 
-  -- Update serial columns to ensure copied table doesn't follow same sequence as primary table
-  SELECT INTO _sql
-      string_agg('CREATE SEQUENCE ' || seq, E';\n') || E';\n'
-      || string_agg(format('ALTER SEQUENCE %s OWNED BY %I.%I'
-                          , seq, _newtable, a.attname), E';\n') || E';\n'
-      || 'ALTER TABLE ' || quote_ident(_newtable) || E'\n  '
-      || string_agg(format($$ALTER %I SET DEFAULT nextval('%s'::regclass)$$
-                                  , a.attname, seq), E'\n, ')
-  FROM   pg_attribute  a
-  JOIN   pg_attrdef    ad ON ad.adrelid = a.attrelid
-                      AND ad.adnum   = a.attnum
-      , quote_ident(_newtable || '_' || a.attname || '_seq') AS seq
-  WHERE  a.attrelid = _table
-  AND    a.attnum > 0
-  AND    NOT a.attisdropped
-  AND    a.atttypid = ANY ('{int,int8,int2}'::regtype[])
-  AND    ad.adsrc = 'nextval('''
+    -- Update serial columns to ensure copied table doesn't follow same sequence as primary table
+    SELECT INTO _sql
+        string_agg('CREATE SEQUENCE ' || seq, E';\n') || E';\n'
+        || string_agg(format('ALTER SEQUENCE %s OWNED BY %I.%I'
+                            , seq, _newtable, a.attname), E';\n') || E';\n'
+        || 'ALTER TABLE ' || quote_ident(_newtable) || E'\n  '
+        || string_agg(format($$ALTER %I SET DEFAULT nextval('%s'::regclass)$$
+                                    , a.attname, seq), E'\n, ')
+    FROM   pg_attribute  a
+    JOIN   pg_attrdef    ad ON ad.adrelid = a.attrelid
+                        AND ad.adnum   = a.attnum
+        , quote_ident(_newtable || '_' || a.attname || '_seq') AS seq
+    WHERE  a.attrelid = _table
+    AND    a.attnum > 0
+    AND    NOT a.attisdropped
+    AND    a.atttypid = ANY ('{int,int8,int2}'::regtype[])
+    AND    pg_get_expr(ad.adbin, ad.adrelid) = 'nextval('''
           || (pg_get_serial_sequence (a.attrelid::regclass::text, a.attname))::regclass
           || '''::regclass)'
   ;

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -247,13 +247,14 @@ module PgOnlineSchemaChange
       def swap!
         @old_primary_table = "pgosc_old_primary_table_#{client.table}"
         foreign_key_statements = Query.get_foreign_keys_to_refresh(client, client.table)
+        storage_params_reset = primary_table_storage_parameters.nil? ? "" : "ALTER TABLE #{client.table} SET (#{primary_table_storage_parameters})"
 
         sql = <<~SQL
           LOCK TABLE #{client.table} IN ACCESS EXCLUSIVE MODE;
           ALTER TABLE #{client.table} RENAME to #{old_primary_table};
           ALTER TABLE #{shadow_table} RENAME to #{client.table};
           #{foreign_key_statements}
-          #{primary_table_storage_parameters}
+          #{storage_params_reset}
         SQL
 
         Query.run(client.connection, sql)

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -201,10 +201,7 @@ module PgOnlineSchemaChange
           columns = result.map { |row| row["params"] }
         end
 
-        result = columns.first
-        return "" if result.nil?
-
-        "ALTER TABLE #{client.table} SET (#{result})"
+        columns.first
       end
     end
   end

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -201,7 +201,10 @@ module PgOnlineSchemaChange
           columns = result.map { |row| row["params"] }
         end
 
-        columns.first
+        result = columns.first
+        return "" if result.nil?
+
+        "ALTER TABLE #{client.table} SET (#{result})"
       end
     end
   end

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -190,6 +190,19 @@ module PgOnlineSchemaChange
 
         columns.first
       end
+
+      def storage_parameters_for(client, table)
+        query = <<~SQL
+          SELECT array_to_string(reloptions, ',') as params FROM pg_class WHERE relname=\'#{table}\';
+        SQL
+
+        columns = []
+        run(client.connection, query) do |result|
+          columns = result.map { |row| row["params"] }
+        end
+
+        columns.first
+      end
     end
   end
 end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe PgOnlineSchemaChange::Client do
     expect(client.port).to eq(5432)
     expect(client.connection).to be_instance_of(PG::Connection)
     expect(client.table).to eq("books")
+    expect(client.drop).to eq(false)
   end
 
   it "raises error query is not ALTER" do

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
       described_class.disable_vacuum!
 
-      expect(described_class.primary_table_storage_parameters).to eq("ALTER TABLE books SET (autovacuum_enabled=true,autovacuum_vacuum_scale_factor=0,autovacuum_vacuum_threshold=20000)")
+      expect(described_class.primary_table_storage_parameters).to eq("autovacuum_enabled=true,autovacuum_vacuum_scale_factor=0,autovacuum_vacuum_threshold=20000")
       RSpec::Mocks.space.reset_all
 
       query = <<~SQL

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -340,10 +340,13 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         );
       SQL
       expect(client.connection).to receive(:async_exec).with("BEGIN;").and_call_original
+      expect(client.connection).to receive(:async_exec).with("SELECT array_to_string(reloptions, ',') as params FROM pg_class WHERE relname='books';\n").and_call_original
       expect(client.connection).to receive(:async_exec).with(query).and_call_original
       expect(client.connection).to receive(:async_exec).with("COMMIT;").and_call_original
 
       described_class.disable_vacuum!
+
+      expect(described_class.primary_table_storage_parameters).to eq("autovacuum_enabled=true,autovacuum_vacuum_scale_factor=0,autovacuum_vacuum_threshold=20000")
       RSpec::Mocks.space.reset_all
 
       query = <<~SQL

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -477,7 +477,14 @@ RSpec.describe PgOnlineSchemaChange::Query do
       client = PgOnlineSchemaChange::Client.new(client_options)
 
       result = described_class.storage_parameters_for(client, "books")
-      expect(result).to eq("autovacuum_enabled=true,autovacuum_vacuum_scale_factor=0,autovacuum_vacuum_threshold=20000")
+      expect(result).to eq("ALTER TABLE books SET (autovacuum_enabled=true,autovacuum_vacuum_scale_factor=0,autovacuum_vacuum_threshold=20000)")
+    end
+
+    it "returns empty string when no sotrage params exist" do
+      client = PgOnlineSchemaChange::Client.new(client_options)
+
+      result = described_class.storage_parameters_for(client, "sellers")
+      expect(result).to eq("")
     end
   end
 end

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -477,14 +477,14 @@ RSpec.describe PgOnlineSchemaChange::Query do
       client = PgOnlineSchemaChange::Client.new(client_options)
 
       result = described_class.storage_parameters_for(client, "books")
-      expect(result).to eq("ALTER TABLE books SET (autovacuum_enabled=true,autovacuum_vacuum_scale_factor=0,autovacuum_vacuum_threshold=20000)")
+      expect(result).to eq("autovacuum_enabled=true,autovacuum_vacuum_scale_factor=0,autovacuum_vacuum_threshold=20000")
     end
 
     it "returns empty string when no sotrage params exist" do
       client = PgOnlineSchemaChange::Client.new(client_options)
 
       result = described_class.storage_parameters_for(client, "sellers")
-      expect(result).to eq("")
+      expect(result).to eq(nil)
     end
   end
 end

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -471,4 +471,13 @@ RSpec.describe PgOnlineSchemaChange::Query do
       expect(result).to eq([])
     end
   end
+
+  describe ".storage_parameters_for" do
+    it "returns all the parameters succesfully" do
+      client = PgOnlineSchemaChange::Client.new(client_options)
+
+      result = described_class.storage_parameters_for(client, "books")
+      expect(result).to eq("autovacuum_enabled=true,autovacuum_vacuum_scale_factor=0,autovacuum_vacuum_threshold=20000")
+    end
+  end
 end

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -12,6 +12,7 @@ module DatabaseHelpers
       username: ENV["POSTGRES_USER"] || "jamesbond",
       password: ENV["POSTGRES_PASSWORD"] || "password",
       port: ENV["port"] || 5432,
+      drop: false,
     }
     Struct.new(*options.keys).new(*options.values)
   end
@@ -44,6 +45,8 @@ module DatabaseHelpers
         created_on TIMESTAMP NOT NULL,
         last_login TIMESTAMP
       );
+
+      ALTER ROLE jamesbond SET statement_timeout = 60000;
     SQL
   end
 

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -35,7 +35,7 @@ module DatabaseHelpers
         email VARCHAR ( 255 ) UNIQUE NOT NULL,
         created_on TIMESTAMP NOT NULL,
         last_login TIMESTAMP
-      );
+      ) WITH (autovacuum_enabled=true,autovacuum_vacuum_scale_factor=0,autovacuum_vacuum_threshold=20000);
 
       CREATE TABLE IF NOT EXISTS #{schema}.chapters (
         id serial PRIMARY KEY,


### PR DESCRIPTION
- Query.storage_parameters_for returns storage params (vaccum, fill_factor, etc)
to be reset post swap on the new table.

- This drops the old primary table. The setting
is controlled via -f/--drop flag. Default being false (won't drop)

- Audit table is dropped by default (since its empty)

- statement_timeout and client_min_messages are reset

- Updated fix_serial_sequence to use `pg_attrdef.adbin`
since `adsrc` is deprecated and removed in PG12 onwards.
Also this handles schemas nicely when search_path is set.

closes https://github.com/shayonj/pg-online-schema-change/issues/12