### PR TITLE
Validate constraints post swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ print the version
    - swap table names (shadow table <> parent table).
    - update references in other tables (FKs) by dropping and re-creating the FKs with a `NOT VALID`.
 8. Runs `ANALYZE` on the new table.
-9. Drop parent (now old) table (OPTIONAL).
+9. Validates all FKs that were added with `NOT VALID`.
+10. Drop parent (now old) table (OPTIONAL).
 
 ### Prominent features
 - It supports when a column is being added, dropped or renamed with no data loss. 


### PR DESCRIPTION
This way we validate the FKs that were added
w/ NOT VALID during the swap. This is a safe operation
to run post swap (since it doesn't block on the lock).
Also leaves the `pg_get_constraintdef` in a good state.
In other words, post this step, the FK's won't have NOT VALID,
that were added during the swap

closes https://github.com/shayonj/pg-online-schema-change/issues/11