### PR TITLE
Fixes post first stress test

### DIFF
--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -128,7 +128,6 @@ module PgOnlineSchemaChange
 
         @parent_table_columns = Query.table_columns(client).map { |entry| entry["column_name"] }
         columns = parent_table_columns.join(", ")
-
         sql = <<~SQL
           INSERT INTO #{shadow_table}
           SELECT #{columns}
@@ -178,6 +177,7 @@ module PgOnlineSchemaChange
         PgOnlineSchemaChange.logger.info("Replaying rows, count: #{rows.size}")
 
         to_be_deleted_rows = []
+        to_be_replayed = []
         rows.each do |row|
           new_row = row.dup
 
@@ -202,6 +202,16 @@ module PgOnlineSchemaChange
 
           new_row = new_row.compact
 
+          # quote indent column to preserve case insensitivity
+          # ensure rows are escaped
+          new_row = new_row.transform_keys do |column|
+            client.connection.quote_ident(column)
+          end
+
+          new_row = new_row.transform_values do |value|
+            client.connection.escape_string(value)
+          end
+
           case row["operation_type"]
           when "INSERT"
             values = new_row.map { |_, val| "'#{val}'" }.join(",")
@@ -210,9 +220,9 @@ module PgOnlineSchemaChange
               INSERT INTO #{shadow_table} (#{new_row.keys.join(",")})
               VALUES (#{values});
             SQL
-            Query.run(client.connection, sql)
+            to_be_replayed << sql
 
-            to_be_deleted_rows << new_row[primary_key]
+            to_be_deleted_rows << "'#{row[primary_key]}'"
           when "UPDATE"
             set_values = new_row.map do |column, value|
               "#{column} = '#{value}'"
@@ -223,17 +233,20 @@ module PgOnlineSchemaChange
               SET #{set_values}
               WHERE #{primary_key}=\'#{row[primary_key]}\';
             SQL
-            Query.run(client.connection, sql)
+            to_be_replayed << sql
 
-            to_be_deleted_rows << row[primary_key]
+            to_be_deleted_rows << "'#{row[primary_key]}'"
           when "DELETE"
             sql = <<~SQL
               DELETE FROM #{shadow_table} WHERE #{primary_key}=\'#{row[primary_key]}\';
             SQL
-            Query.run(client.connection, sql)
-            to_be_deleted_rows << row[primary_key]
+            to_be_replayed << sql
+
+            to_be_deleted_rows << "'#{row[primary_key]}'"
           end
         end
+
+        Query.run(client.connection, to_be_replayed.join)
 
         # Delete items from the audit now that are replayed
         if to_be_deleted_rows.count >= 1
@@ -265,11 +278,15 @@ module PgOnlineSchemaChange
       end
 
       def drop_and_cleanup!
-        drop_primary = client.drop ? "DROP TABLE IF EXISTS #{old_primary_table};" : ""
+        primary_drop = client.drop ? "DROP TABLE IF EXISTS #{old_primary_table};" : ""
+        audit_table_drop = audit_table ? "DROP TABLE IF EXISTS #{audit_table}" : ""
+        shadow_table_drop = shadow_table ? "DROP TABLE IF EXISTS #{shadow_table}" : ""
 
         sql = <<~SQL
-          DROP TABLE IF EXISTS #{audit_table};
-          #{drop_primary}
+          DROP TRIGGER IF EXISTS primary_to_audit_table_trigger ON #{client.table};
+          #{audit_table_drop};
+          #{shadow_table_drop};
+          #{primary_drop}
           RESET statement_timeout;
           RESET client_min_messages;
         SQL

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -64,6 +64,7 @@ module PgOnlineSchemaChange
 
         run(client.connection, sql) do |result|
           mapped_columns = result.map do |row|
+            row["column_name"] = client.connection.quote_ident(row["column_name"])
             row["column_position"] = row["column_position"].to_i
             row
           end

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "pry"
 RSpec.describe PgOnlineSchemaChange::Orchestrate do
   describe ".setup!" do
     let(:client) { PgOnlineSchemaChange::Client.new(client_options) }
@@ -78,24 +77,22 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
       RSpec::Mocks.space.reset_all
       columns = PgOnlineSchemaChange::Query.table_columns(client, "pgosc_audit_table_for_books")
+
       expect(columns).to eq([
-                              { "column_name" => "operation_type", "type" => "text",
-                                "column_position" => 1 },
-                              { "column_name" => "trigger_time", "type" => "timestamp without time zone",
+                              { "column_name" => "\"operation_type\"", "type" => "text", "column_position" => 1 },
+                              { "column_name" => "\"trigger_time\"", "type" => "timestamp without time zone",
                                 "column_position" => 2 },
-                              { "column_name" => "user_id", "type" => "integer",
-                                "column_position" => 3 },
-                              { "column_name" => "username", "type" => "character varying(50)",
+                              { "column_name" => "\"user_id\"", "type" => "integer", "column_position" => 3 },
+                              { "column_name" => "\"username\"", "type" => "character varying(50)",
                                 "column_position" => 4 },
-                              { "column_name" => "seller_id", "type" => "integer",
-                                "column_position" => 5 },
-                              { "column_name" => "password", "type" => "character varying(50)",
+                              { "column_name" => "\"seller_id\"", "type" => "integer", "column_position" => 5 },
+                              { "column_name" => "\"password\"", "type" => "character varying(50)",
                                 "column_position" => 6 },
-                              { "column_name" => "email", "type" => "character varying(255)",
+                              { "column_name" => "\"email\"", "type" => "character varying(255)",
                                 "column_position" => 7 },
-                              { "column_name" => "created_on", "type" => "timestamp without time zone",
+                              { "column_name" => "\"createdOn\"", "type" => "timestamp without time zone",
                                 "column_position" => 8 },
-                              { "column_name" => "last_login", "type" => "timestamp without time zone",
+                              { "column_name" => "\"last_login\"", "type" => "timestamp without time zone",
                                 "column_position" => 9 },
                             ])
     end
@@ -180,11 +177,11 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
       described_class.setup_trigger!
 
       query = <<~SQL
-        INSERT INTO "sellers"("name", "created_on", "last_login")
+        INSERT INTO "sellers"("name", "createdOn", "last_login")
         VALUES('local shop', 'now()', 'now()');
 
-        INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "created_on", "last_login")
-        VALUES(1, 1, 'jamesbond', '007', 'james@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "created_on", "last_login";
+        INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
+        VALUES(1, 1, 'jamesbond', '007', 'james@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
 
         UPDATE books SET username = 'bondjames'
         WHERE user_id='1';
@@ -212,7 +209,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         "username" => "jamesbond",
         "password" => "007",
         "email" => "james@bond.com",
-        "created_on" => be_instance_of(String),
+        "createdOn" => be_instance_of(String),
         "last_login" => be_instance_of(String),
       )
 
@@ -224,7 +221,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         "username" => "bondjames",
         "password" => "007",
         "email" => "james@bond.com",
-        "created_on" => be_instance_of(String),
+        "createdOn" => be_instance_of(String),
         "last_login" => be_instance_of(String),
       )
 
@@ -236,7 +233,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         "username" => "bondjames",
         "password" => "007",
         "email" => "james@bond.com",
-        "created_on" => be_instance_of(String),
+        "createdOn" => be_instance_of(String),
         "last_login" => be_instance_of(String),
       )
     end
@@ -266,21 +263,20 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
       RSpec::Mocks.space.reset_all
       columns = PgOnlineSchemaChange::Query.table_columns(client, described_class.shadow_table)
+
       expect(columns).to eq([
-                              { "column_name" => "user_id", "type" => "integer",
-                                "column_position" => 1 },
-                              { "column_name" => "username", "type" => "character varying(50)",
+                              { "column_name" => "\"user_id\"", "type" => "integer", "column_position" => 1 },
+                              { "column_name" => "\"username\"", "type" => "character varying(50)",
                                 "column_position" => 2 },
-                              { "column_name" => "seller_id", "type" => "integer",
-                                "column_position" => 3 },
-                              { "column_name" => "password", "type" => "character varying(50)",
+                              { "column_name" => "\"seller_id\"", "type" => "integer", "column_position" => 3 },
+                              { "column_name" => "\"password\"", "type" => "character varying(50)",
                                 "column_position" => 4 },
-                              { "column_name" => "email", "type" => "character varying(255)",
+                              { "column_name" => "\"email\"", "type" => "character varying(255)",
                                 "column_position" => 5 },
-                              { "column_name" => "created_on", "type" => "timestamp without time zone",
+                              { "column_name" => "\"createdOn\"", "type" => "timestamp without time zone",
                                 "column_position" => 6 },
-                              { "column_name" => "last_login",
-                                "type" => "timestamp without time zone", "column_position" => 7 },
+                              { "column_name" => "\"last_login\"", "type" => "timestamp without time zone",
+                                "column_position" => 7 },
                             ])
 
       columns = PgOnlineSchemaChange::Query.get_indexes_for(client, "pgosc_shadow_table_for_books")
@@ -390,7 +386,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
       SQL
       insert_query = <<~SQL
         INSERT INTO pgosc_shadow_table_for_books
-        SELECT user_id, username, seller_id, password, email, created_on, last_login
+        SELECT \"user_id\", \"username\", \"seller_id\", \"password\", \"email\", \"createdOn\", \"last_login\"
         FROM ONLY books
       SQL
       expect(client.connection).to receive(:async_exec).with("BEGIN;").twice.and_call_original
@@ -417,7 +413,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
       expect(rows.map do |r|
         r["email"]
       end).to eq(["james1@bond.com", "james2@bond.com", "james3@bond.com"])
-      expect(rows.all? { |r| !r["created_on"].nil? }).to eq(true)
+      expect(rows.all? { |r| !r["createdOn"].nil? }).to eq(true)
       expect(rows.all? { |r| !r["last_login"].nil? }).to eq(true)
     end
   end
@@ -443,23 +439,21 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
       RSpec::Mocks.space.reset_all
 
       columns = PgOnlineSchemaChange::Query.table_columns(client, described_class.shadow_table)
+
       expect(columns).to eq([
-                              { "column_name" => "user_id", "type" => "integer",
-                                "column_position" => 1 },
-                              { "column_name" => "username", "type" => "character varying(50)",
+                              { "column_name" => "\"user_id\"", "type" => "integer", "column_position" => 1 },
+                              { "column_name" => "\"username\"", "type" => "character varying(50)",
                                 "column_position" => 2 },
-                              { "column_name" => "seller_id", "type" => "integer",
-                                "column_position" => 3 },
-                              { "column_name" => "password", "type" => "character varying(50)",
+                              { "column_name" => "\"seller_id\"", "type" => "integer", "column_position" => 3 },
+                              { "column_name" => "\"password\"", "type" => "character varying(50)",
                                 "column_position" => 4 },
-                              { "column_name" => "email", "type" => "character varying(255)",
+                              { "column_name" => "\"email\"", "type" => "character varying(255)",
                                 "column_position" => 5 },
-                              { "column_name" => "created_on", "type" => "timestamp without time zone",
+                              { "column_name" => "\"createdOn\"", "type" => "timestamp without time zone",
                                 "column_position" => 6 },
-                              { "column_name" => "last_login", "type" => "timestamp without time zone",
+                              { "column_name" => "\"last_login\"", "type" => "timestamp without time zone",
                                 "column_position" => 7 },
-                              { "column_name" => "purchased", "type" => "boolean",
-                                "column_position" => 8 },
+                              { "column_name" => "\"purchased\"", "type" => "boolean", "column_position" => 8 },
                             ])
       expect(described_class.dropped_columns).to eq([])
       expect(described_class.renamed_columns).to eq([])
@@ -494,18 +488,17 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         RSpec::Mocks.space.reset_all
 
         columns = PgOnlineSchemaChange::Query.table_columns(client, described_class.shadow_table)
+
         expect(columns).to eq([
-                                { "column_name" => "user_id", "type" => "integer",
-                                  "column_position" => 1 },
-                                { "column_name" => "username", "type" => "character varying(50)",
+                                { "column_name" => "\"user_id\"", "type" => "integer", "column_position" => 1 },
+                                { "column_name" => "\"username\"", "type" => "character varying(50)",
                                   "column_position" => 2 },
-                                { "column_name" => "seller_id", "type" => "integer",
-                                  "column_position" => 3 },
-                                { "column_name" => "password", "type" => "character varying(50)",
+                                { "column_name" => "\"seller_id\"", "type" => "integer", "column_position" => 3 },
+                                { "column_name" => "\"password\"", "type" => "character varying(50)",
                                   "column_position" => 4 },
-                                { "column_name" => "created_on", "type" => "timestamp without time zone",
+                                { "column_name" => "\"createdOn\"", "type" => "timestamp without time zone",
                                   "column_position" => 6 },
-                                { "column_name" => "last_login", "type" => "timestamp without time zone",
+                                { "column_name" => "\"last_login\"", "type" => "timestamp without time zone",
                                   "column_position" => 7 },
                               ])
         expect(described_class.dropped_columns).to eq(["email"])
@@ -540,22 +533,22 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         RSpec::Mocks.space.reset_all
 
         columns = PgOnlineSchemaChange::Query.table_columns(client, described_class.shadow_table)
+
         expect(columns).to eq([
-                                { "column_name" => "user_id", "type" => "integer",
-                                  "column_position" => 1 },
-                                { "column_name" => "username", "type" => "character varying(50)",
+                                { "column_name" => "\"user_id\"", "type" => "integer", "column_position" => 1 },
+                                { "column_name" => "\"username\"", "type" => "character varying(50)",
                                   "column_position" => 2 },
-                                { "column_name" => "seller_id", "type" => "integer",
-                                  "column_position" => 3 },
-                                { "column_name" => "password", "type" => "character varying(50)",
+                                { "column_name" => "\"seller_id\"", "type" => "integer", "column_position" => 3 },
+                                { "column_name" => "\"password\"", "type" => "character varying(50)",
                                   "column_position" => 4 },
-                                { "column_name" => "new_email", "type" => "character varying(255)",
+                                { "column_name" => "\"new_email\"", "type" => "character varying(255)",
                                   "column_position" => 5 },
-                                { "column_name" => "created_on", "type" => "timestamp without time zone",
+                                { "column_name" => "\"createdOn\"", "type" => "timestamp without time zone",
                                   "column_position" => 6 },
-                                { "column_name" => "last_login", "type" => "timestamp without time zone",
+                                { "column_name" => "\"last_login\"", "type" => "timestamp without time zone",
                                   "column_position" => 7 },
                               ])
+
         expect(described_class.dropped_columns).to eq([])
         expect(described_class.renamed_columns).to eq([
                                                         {
@@ -601,8 +594,11 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
         # Add an entry for the trigger
         query = <<~SQL
-          INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "created_on", "last_login")
-          VALUES(10, 1, 'jamesbond10', '0010', 'james10@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "created_on", "last_login";
+          INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
+          VALUES(10, 1, 'jamesbond10 "''i am bond 🚀''"', '0010', 'james10@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
+
+          INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
+          VALUES(11, 1, 'jamesbond11 "''i am bond 🚀''"', '0011', 'james11@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
         SQL
         PgOnlineSchemaChange::Query.run(client.connection, query)
 
@@ -627,7 +623,8 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         expect(shadow_rows.first["seller_id"]).to eq("1")
         expect(shadow_rows.first["password"]).to eq("0010")
         expect(shadow_rows.first["email"]).to eq("james10@bond.com")
-        expect(shadow_rows.all? { |r| !r["created_on"].nil? }).to eq(true)
+        expect(shadow_rows.first["username"]).to eq("jamesbond10 \"'i am bond 🚀'\"")
+        expect(shadow_rows.all? { |r| !r["createdOn"].nil? }).to eq(true)
         expect(shadow_rows.all? { |r| !r["last_login"].nil? }).to eq(true)
 
         # Expect row being removed from audit table
@@ -685,7 +682,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         expect(shadow_rows.first["seller_id"]).to eq("1")
         expect(shadow_rows.first["password"]).to eq("007")
         expect(shadow_rows.first["email"]).to eq("james1@bond.com")
-        expect(shadow_rows.all? { |r| !r["created_on"].nil? }).to eq(true)
+        expect(shadow_rows.all? { |r| !r["createdOn"].nil? }).to eq(true)
         expect(shadow_rows.all? { |r| !r["last_login"].nil? }).to eq(true)
 
         # Expect row being removed from audit table
@@ -800,8 +797,8 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
         # Add an entry for the trigger
         query = <<~SQL
-          INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "created_on", "last_login")
-          VALUES(10, 1, 'jamesbond10', '0010', 'james10@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "created_on", "last_login";
+          INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
+          VALUES(10, 1, 'jamesbond10', '0010', 'james10@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
         SQL
         PgOnlineSchemaChange::Query.run(client.connection, query)
 
@@ -826,7 +823,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         expect(shadow_rows.first["seller_id"]).to eq("1")
         expect(shadow_rows.first["password"]).to eq("0010")
         expect(shadow_rows.first["email"]).to eq(nil)
-        expect(shadow_rows.all? { |r| !r["created_on"].nil? }).to eq(true)
+        expect(shadow_rows.all? { |r| !r["createdOn"].nil? }).to eq(true)
         expect(shadow_rows.all? { |r| !r["last_login"].nil? }).to eq(true)
 
         # Expect row being removed from audit table
@@ -886,7 +883,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         expect(shadow_rows.first["seller_id"]).to eq("1")
         expect(shadow_rows.first["password"]).to eq("007")
         expect(shadow_rows.first["email"]).to eq(nil)
-        expect(shadow_rows.all? { |r| !r["created_on"].nil? }).to eq(true)
+        expect(shadow_rows.all? { |r| !r["createdOn"].nil? }).to eq(true)
         expect(shadow_rows.all? { |r| !r["last_login"].nil? }).to eq(true)
 
         # Expect row being removed from audit table
@@ -945,8 +942,8 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
         # Add an entry for the trigger
         query = <<~SQL
-          INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "created_on", "last_login")
-          VALUES(10, 1, 'jamesbond10', '0010', 'james10@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "created_on", "last_login";
+          INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
+          VALUES(10, 1, 'jamesbond10', '0010', 'james10@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
         SQL
         PgOnlineSchemaChange::Query.run(client.connection, query)
 
@@ -972,7 +969,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         expect(shadow_rows.first["password"]).to eq("0010")
         expect(shadow_rows.first["email"]).to eq(nil)
         expect(shadow_rows.first["new_email"]).to eq("james10@bond.com")
-        expect(shadow_rows.all? { |r| !r["created_on"].nil? }).to eq(true)
+        expect(shadow_rows.all? { |r| !r["createdOn"].nil? }).to eq(true)
         expect(shadow_rows.all? { |r| !r["last_login"].nil? }).to eq(true)
 
         # Expect row being removed from audit table
@@ -1035,7 +1032,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         expect(shadow_rows.first["password"]).to eq("007")
         expect(shadow_rows.first["email"]).to eq(nil)
         expect(shadow_rows.first["new_email"]).to eq("james1@bond.com")
-        expect(shadow_rows.all? { |r| !r["created_on"].nil? }).to eq(true)
+        expect(shadow_rows.all? { |r| !r["createdOn"].nil? }).to eq(true)
         expect(shadow_rows.all? { |r| !r["last_login"].nil? }).to eq(true)
 
         # Expect row being removed from audit table

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -172,16 +172,15 @@ RSpec.describe PgOnlineSchemaChange::Query do
 
     it "returns column names" do
       described_class.run(client.connection, new_dummy_table_sql)
+
       result = [
-        { "column_name" => "user_id", "type" => "integer", "column_position" => 1 },
-        { "column_name" => "username", "type" => "character varying(50)", "column_position" => 2 },
-        { "column_name" => "seller_id", "type" => "integer", "column_position" => 3 },
-        { "column_name" => "password", "type" => "character varying(50)", "column_position" => 4 },
-        { "column_name" => "email", "type" => "character varying(255)", "column_position" => 5 },
-        { "column_name" => "created_on", "type" => "timestamp without time zone",
-          "column_position" => 6 },
-        { "column_name" => "last_login", "type" => "timestamp without time zone",
-          "column_position" => 7 },
+        { "column_name" => "\"user_id\"", "type" => "integer", "column_position" => 1 },
+        { "column_name" => "\"username\"", "type" => "character varying(50)", "column_position" => 2 },
+        { "column_name" => "\"seller_id\"", "type" => "integer", "column_position" => 3 },
+        { "column_name" => "\"password\"", "type" => "character varying(50)", "column_position" => 4 },
+        { "column_name" => "\"email\"", "type" => "character varying(255)", "column_position" => 5 },
+        { "column_name" => "\"createdOn\"", "type" => "timestamp without time zone", "column_position" => 6 },
+        { "column_name" => "\"last_login\"", "type" => "timestamp without time zone", "column_position" => 7 },
       ]
 
       expect(described_class.table_columns(client)).to eq(result)

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -24,7 +24,7 @@ module DatabaseHelpers
       CREATE TABLE IF NOT EXISTS #{schema}.sellers (
         id serial PRIMARY KEY,
         name VARCHAR ( 50 ) UNIQUE NOT NULL,
-        created_on TIMESTAMP NOT NULL,
+        "createdOn" TIMESTAMP NOT NULL,
         last_login TIMESTAMP
       );
 
@@ -34,7 +34,7 @@ module DatabaseHelpers
         seller_id SERIAL REFERENCES #{schema}.sellers NOT NULL,
         password VARCHAR ( 50 ) NOT NULL,
         email VARCHAR ( 255 ) UNIQUE NOT NULL,
-        created_on TIMESTAMP NOT NULL,
+        "createdOn" TIMESTAMP NOT NULL,
         last_login TIMESTAMP
       ) WITH (autovacuum_enabled=true,autovacuum_vacuum_scale_factor=0,autovacuum_vacuum_threshold=20000);
 
@@ -42,7 +42,7 @@ module DatabaseHelpers
         id serial PRIMARY KEY,
         name VARCHAR ( 50 ) UNIQUE NOT NULL,
         book_id SERIAL REFERENCES #{schema}.books NOT NULL,
-        created_on TIMESTAMP NOT NULL,
+        "createdOn" TIMESTAMP NOT NULL,
         last_login TIMESTAMP
       );
 
@@ -64,10 +64,10 @@ module DatabaseHelpers
   def ingest_dummy_data_into_dummy_table(client = nil)
     client ||= PgOnlineSchemaChange::Client.new(client_options)
     query = <<~SQL
-      INSERT INTO "#{schema}"."sellers"("name", "created_on", "last_login")
+      INSERT INTO "#{schema}"."sellers"("name", "createdOn", "last_login")
       VALUES('local shop', 'now()', 'now()');
 
-      INSERT INTO "#{schema}"."books"("user_id", "seller_id", "username", "password", "email", "created_on", "last_login")
+      INSERT INTO "#{schema}"."books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
       VALUES
         (2, 1, 'jamesbond2', '007', 'james1@bond.com', 'now()', 'now()'),
         (3, 1, 'jamesbond3', '008', 'james2@bond.com', 'now()', 'now()'),


### PR DESCRIPTION
First stress test was good. Came across some issues and
here are the fixes

- Escape rows being replayed. Rows can contain
quotes, emojis, etc. Using escape_string for this.

- Respect case sensitive columns. Using quote_indent
for this

- Replay all 1000 rows at once. Replaying 1 row at
a time, leads to a very slow migration.

- Ensure primary keys are quoted since they can
be string/uuid as well

- Ensure triggers and shadow tables are cleaned, 
in case process breaks mid way before alter, swap, etc