### PR TITLE
Introduce the ability to kill competing transactions that hold exclusive lock during swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,20 @@ Usage:
   pg-online-schema-change perform -a, --alter-statement=ALTER_STATEMENT -d, --dbname=DBNAME -h, --host=HOST -p, --port=N -s, --schema=SCHEMA -u, --username=USERNAME -w, --password=PASSWORD
 
 Options:
-  -a, --alter-statement=ALTER_STATEMENT  # The ALTER statement to perform the schema change
-  -s, --schema=SCHEMA                    # The schema in which the table is
-                                         # Default: public
-  -d, --dbname=DBNAME                    # Name of the database
-  -h, --host=HOST                        # Server host where the Database is located
-  -u, --username=USERNAME                # Username for the Database
-  -p, --port=N                           # Port for the Database
-                                         # Default: 5432
-  -w, --password=PASSWORD                # Password for the Database
-  -v, [--verbose], [--no-verbose]        # Emit logs in debug mode
-  -f, [--drop], [--no-drop]              # Drop the original table in the end after the swap
+  -a, --alter-statement=ALTER_STATEMENT        # The ALTER statement to perform the schema change
+  -s, --schema=SCHEMA                          # The schema in which the table is
+                                               # Default: public
+  -d, --dbname=DBNAME                          # Name of the database
+  -h, --host=HOST                              # Server host where the Database is located
+  -u, --username=USERNAME                      # Username for the Database
+  -p, --port=N                                 # Port for the Database
+                                               # Default: 5432
+  -w, --password=PASSWORD                      # Password for the Database
+  -v, [--verbose], [--no-verbose]              # Emit logs in debug mode
+  -f, [--drop], [--no-drop]                    # Drop the original table in the end after the swap
+  -k, [--kill-backends], [--no-kill-backends]  # Kill other competing queries/backends when trying to acquire lock for the swap. It will wait for --wait-time-for-lock duration before killing backends and try upto 3 times.
+  -w, [--wait-time-for-lock=N]                 # Time to wait before killing backends to acquire lock and/or retrying upto 3 times. It will kill backends if --kill-backends is true, otherwise try upto 3 times and exit if it cannot acquire a lock.
+                                               # Default: 10
 ```
 
 ```

--- a/lib/pg_online_schema_change.rb
+++ b/lib/pg_online_schema_change.rb
@@ -13,14 +13,15 @@ require "pg_online_schema_change/orchestrate"
 module PgOnlineSchemaChange
   class Error < StandardError; end
   class CountBelowDelta < StandardError; end
+  class AccessExclusiveLockNotAcquired < StandardError; end
 
   def self.logger=(verbose)
     @@logger ||= begin
-      logger = Ougai::Logger.new($stdout)
-      logger.level = verbose ? Ougai::Logger::TRACE : Ougai::Logger::INFO
-      logger.with_fields = { version: PgOnlineSchemaChange::VERSION }
-      logger
-    end
+        logger = Ougai::Logger.new($stdout)
+        logger.level = verbose ? Ougai::Logger::TRACE : Ougai::Logger::INFO
+        logger.with_fields = { version: PgOnlineSchemaChange::VERSION }
+        logger
+      end
   end
 
   def self.logger

--- a/lib/pg_online_schema_change/cli.rb
+++ b/lib/pg_online_schema_change/cli.rb
@@ -15,6 +15,10 @@ module PgOnlineSchemaChange
     method_option :verbose, aliases: "-v", type: :boolean, default: false, desc: "Emit logs in debug mode"
     method_option :drop, aliases: "-f", type: :boolean, default: false,
                          desc: "Drop the original table in the end after the swap"
+    method_option :kill_backends, aliases: "-k", type: :boolean, default: false,
+                                  desc: "Kill other competing queries/backends when trying to acquire lock for the swap. It will wait for --wait-time-for-lock duration before killing backends and try upto 3 times."
+    method_option :wait_time_for_lock, aliases: "-w", type: :numeric, default: 10,
+                                       desc: "Time to wait before killing backends to acquire lock and/or retrying upto 3 times. It will kill backends if --kill-backends is true, otherwise try upto 3 times and exit if it cannot acquire a lock."
 
     def perform
       client_options = Struct.new(*options.keys.map(&:to_sym)).new(*options.values)

--- a/lib/pg_online_schema_change/client.rb
+++ b/lib/pg_online_schema_change/client.rb
@@ -2,7 +2,8 @@ require "pg"
 
 module PgOnlineSchemaChange
   class Client
-    attr_accessor :alter_statement, :schema, :dbname, :host, :username, :port, :password, :connection, :table, :drop
+    attr_accessor :alter_statement, :schema, :dbname, :host, :username, :port, :password, :connection, :table, :drop,
+                  :kill_backends, :wait_time_for_lock
 
     def initialize(options)
       @alter_statement = options.alter_statement
@@ -13,6 +14,8 @@ module PgOnlineSchemaChange
       @port = options.port
       @password = options.password
       @drop = options.drop
+      @kill_backends = options.kill_backends
+      @wait_time_for_lock = options.wait_time_for_lock
 
       @connection = PG.connect(
         dbname: @dbname,

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -13,6 +13,8 @@ module DatabaseHelpers
       password: ENV["POSTGRES_PASSWORD"] || "password",
       port: ENV["port"] || 5432,
       drop: false,
+      kill_backends: false,
+      wait_time_for_lock: 5,
     }
     Struct.new(*options.keys).new(*options.values)
   end

--- a/todo
+++ b/todo
@@ -7,3 +7,5 @@
 # TODO: SUPPORT TABLE RENAME?
 # TODO: REMOVE _pgsoc suffixes from index name and restore them to their original name
 # TODO: Could hold access share lock on clien.table (primary table) to avoid any DDLs
+# TODO: replay all remaining rows from audit table (since acquiring lock could have been a while)
+# TODO: DROP trigger on screenshots needs to happen from within swap (since the acquire lock exists)


### PR DESCRIPTION
This introduces `wait_time_for_lock` and `kill_backends` as new flags.
By default `pgosc` won't kill any backends if it cannot acquire an
`AccessExclusiveLock` to perform the swap. It will retry upto 3 times
and for the duration specified in `wait_time_for_lock` (default: `10s`).
So, in total 30s. Configurable. If `kill_backends`/`kill-backend`
is set to true (supplied), then it will kill the backend on each try
it couldn't acquire the lock, upto 3 times before exiting. Though,
after killing the backends after 1st attempt should work.

Specs added. A bit messy for now. Refactor in the end

closes https://github.com/shayonj/pg-online-schema-change/issues/16