### PR TITLE
Drop trigger post swap and not cleanup

### DIFF
--- a/todo
+++ b/todo
@@ -1,11 +1,8 @@
 # TODO: support dry run mode
 # TODO: Potential to refactor Orchestrator class and extract some functions into a utility/helper class
 # TODO: Refactor class level vars on Orchestrate. Might need some form of "Store".
-# TODO: Refactor specs. Most are behaving as integration specs. Separate into unit/ and integration/ for starters.
-# TODO: Release process - gem and dockerfile
 # TODO: BEGIN ISOLATION LEVEL SERIALIZABLE for copying rows
 # TODO: SUPPORT TABLE RENAME?
 # TODO: REMOVE _pgsoc suffixes from index name and restore them to their original name
 # TODO: Could hold access share lock on clien.table (primary table) to avoid any DDLs
 # TODO: replay all remaining rows from audit table (since acquiring lock could have been a while)
-# TODO: DROP trigger on screenshots needs to happen from within swap (since the acquire lock exists)


### PR DESCRIPTION
To avoid any other/future strong locks (like during drop/cleanup, which should be simple operations, as it can happen during error handling, or post completion)