### PR TITLE
Replaying remaining <20 rows (below delta) before swap

### DIFF
--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -161,8 +161,7 @@ module PgOnlineSchemaChange
             SELECT * FROM #{audit_table} ORDER BY #{primary_key} LIMIT #{PULL_BATCH_COUNT};
           SQL
 
-          rows = []
-          Query.run(client.connection, select_query) { |result| rows = result.map { |row| row } }
+          rows = select_rows_to_replay
 
           raise CountBelowDelta if rows.count <= DELTA_COUNT
 
@@ -174,7 +173,18 @@ module PgOnlineSchemaChange
         swap!
       end
 
-      def replay_data!(rows)
+      def select_rows_to_replay(reuse_trasaction = false)
+        select_query = <<~SQL
+          SELECT * FROM #{audit_table} ORDER BY #{primary_key} LIMIT #{PULL_BATCH_COUNT};
+        SQL
+
+        rows = []
+        Query.run(client.connection, select_query, reuse_trasaction) { |result| rows = result.map { |row| row } }
+
+        rows
+      end
+
+      def replay_data!(rows, reuse_trasaction = false)
         PgOnlineSchemaChange.logger.info("Replaying rows, count: #{rows.size}")
 
         to_be_deleted_rows = []
@@ -247,14 +257,14 @@ module PgOnlineSchemaChange
           end
         end
 
-        Query.run(client.connection, to_be_replayed.join)
+        Query.run(client.connection, to_be_replayed.join, reuse_trasaction)
 
         # Delete items from the audit now that are replayed
         if to_be_deleted_rows.count >= 1
           delete_query = <<~SQL
             DELETE FROM #{audit_table} WHERE #{primary_key} IN (#{to_be_deleted_rows.join(",")})
           SQL
-          Query.run(client.connection, delete_query)
+          Query.run(client.connection, delete_query, reuse_trasaction)
         end
       end
 
@@ -271,6 +281,9 @@ module PgOnlineSchemaChange
         opened = Query.open_lock_exclusive(client, client.table)
 
         raise AccessExclusiveLockNotAcquired unless opened
+
+        rows = select_rows_to_replay(opened)
+        replay_data!(rows, opened)
 
         sql = <<~SQL
           ALTER TABLE #{client.table} RENAME to #{old_primary_table};


### PR DESCRIPTION
This ensures that when the delta count is < 20 rows (which indicates its time for swap),
it will replay those rows *after* the access exclusive lock
is acquired and then proceed to performing the swap.

This finally ensures no data loss - since we have already
acquired an access exclusive lock and can replay the <20 replays
swiftly, while other backend wait for a brief while and continue on with the process.

Changed Query.run api to support the use of existing
transaction such that lock is held

fixes https://github.com/shayonj/pg-online-schema-change/issues/25

Ran a stress test with `pgbench` and successfully add a new column on a
table with 500M rows with no pending rows in the audit table and no data
loss. Confirmed by ensuring all rows from old primary table exist in new table. 
Will write an integration test for it at some point. Getting closer for launch. 