### PR TITLE
Acquire lock and attempt to kill backends when setting up trigger

### DIFF
--- a/todo
+++ b/todo
@@ -4,5 +4,3 @@
 # TODO: BEGIN ISOLATION LEVEL SERIALIZABLE for copying rows
 # TODO: SUPPORT TABLE RENAME?
 # TODO: REMOVE _pgsoc suffixes from index name and restore them to their original name
-# TODO: Could hold access share lock on clien.table (primary table) to avoid any DDLs
-# TODO: replay all remaining rows from audit table (since acquiring lock could have been a while)


### PR DESCRIPTION
Since we have the ability to kill competing backends (opt-in via a flag),
and additionally setting up trigger requires lock - this change attempts
to first acquire a lock and if kill-backends is supplied then it will kill the
backends and retry again to setup the triggers. If no-kill-backends is provided
it will try upto 3 times and fail.

This also means we will attempt to try and acquire access exclusive lock twice -
once when setting up triggers and once during swap. Accordingly kill backends (if supplied).

Added specs and tested.

This change makes the project feature complete for v1 rollout. Whats pending are
some refactors/code organization, linter and a release process (https://github.com/shayonj/pg-online-schema-change/issues/13), and https://github.com/shayonj/pg-online-schema-change/issues/20