### PR TITLE
Restore index and foreign key names post swap

### DIFF
--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -314,7 +314,6 @@ module PgOnlineSchemaChange
 
         # From here on, all statements are carried out in a single
         # transaction with access exclusive lock
-
         opened = Query.open_lock_exclusive(client, client.table)
 
         raise AccessExclusiveLockNotAcquired unless opened


### PR DESCRIPTION
- First commit introduces new functions on Query
to build the ALTER statements required to restore
the index and foreign key names post swap.
- Second commit performs the operation as part of the swap


fixes https://github.com/shayonj/pg-online-schema-change/issues/20