### PR TITLE
Pass custom copy statement for copy_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# pg-online-schema-change
+# pg-online-schema-change / pg-osc
 
-pg-online-schema-change is a tool for making schema changes (any `ALTER` statements) in Postgres tables with minimal locks, thus helping achieve zero down time schema changes against production workloads. 
+pg-online-schema-change (`pg-osc`) is a tool for making schema changes (any `ALTER` statements) in Postgres tables with minimal locks, thus helping achieve zero downtime schema changes against production workloads. 
 
-pg-online-schema-change is inspired from the design and workings of tools like `pg_repack` and `pt-online-schema-change` for MySQL. Read more [below](#how-does-it-work) on how it works in action, features and any caveats.
+`pg-osc` uses the concept of shadow table to perform schema changes. At a high level, it copies the contents from a primary table to a shadow table, performs the schema change on the shadow table and swaps the table names in the end while preserving all changes to the primary table using triggers (via audit table).
+
+`pg-osc` is inspired by the design and workings of tools like `pg_repack` and `pt-online-schema-change` (MySQL). Read more below on [how does it work](#how-does-it-work), [prominent features](#prominent-features), the [caveats](#caveats) and [examples](#examples)
 
 ⚠️ ⚠️ THIS IS CURRENTLY WIP AND IS CONSIDERED EXPERIMENTAL ⚠️ ⚠️ 
 
@@ -45,9 +47,10 @@ Options:
   -w, --password=PASSWORD                      # Password for the Database
   -v, [--verbose], [--no-verbose]              # Emit logs in debug mode
   -f, [--drop], [--no-drop]                    # Drop the original table in the end after the swap
-  -k, [--kill-backends], [--no-kill-backends]  # Kill other competing queries/backends when trying to acquire lock for the swap. It will wait for --wait-time-for-lock duration before killing backends and try upto 3 times.
+  -k, [--kill-backends], [--no-kill-backends]  # Kill other competing queries/backends when trying to acquire lock for the shadow table creation and swap. It will wait for --wait-time-for-lock duration before killing backends and try upto 3 times.
   -w, [--wait-time-for-lock=N]                 # Time to wait before killing backends to acquire lock and/or retrying upto 3 times. It will kill backends if --kill-backends is true, otherwise try upto 3 times and exit if it cannot acquire a lock.
                                                # Default: 10
+  -c, [--copy-statement=COPY_STATEMENT]        # Takes a .sql file location where you can provide a custom query to be played (ex: backfills) when pg-osc copies data from the primary to the shadow table. More examples in README.
 ```
 
 ```
@@ -58,43 +61,111 @@ print the version
 ```
 ## How does it work
 
-- Primary table: A table against which a potential schema change is to be run
-- Shadow table: A copy of an existing primary table
-- Audit table: A table to store any updates/inserts/delete on a primary table
+- **Primary table**: A table against which a potential schema change is to be run
+- **Shadow table**: A copy of an existing primary table
+- **Audit table**: A table to store any updates/inserts/delete on a primary table
 
 1. Create an audit table to record changes made to the parent table.
-2. Add a trigger on the parent table (for inserts, updates, deletes) to our audit table.
-3. Create new shadow table with all rows from old table.
-4. Run ALTER/migration on the shadow table.
+2. Acquire a brief `ACCESS EXCLUSIVE` lock to add a trigger on the parent table (for inserts, updates, deletes) to the audit table.
+3. Create a new shadow table and run ALTER/migration on the shadow table. 
+4. Copy all rows from the old table.
 5. Build indexes on the new table.
 6. Replay all changes accumulated in the audit table against the shadow table.
-   - Delete rows in audit table as they are replayed.
-7. Once the delta (reamaining rows) is ~20 rows, acquire an access exclusive lock against the parent table, within a transaction and:
+   - Delete rows in the audit table as they are replayed.
+7. Once the delta (remaining rows) is ~20 rows, acquire an `ACCESS EXCLUSIVE` lock against the parent table within a transaction and:
    - swap table names (shadow table <> parent table).
    - update references in other tables (FKs) by dropping and re-creating the FKs with a `NOT VALID`.
 8. Runs `ANALYZE` on the new table.
 9. Validates all FKs that were added with `NOT VALID`.
 10. Drop parent (now old) table (OPTIONAL).
 
-### Prominent features
-- It supports when a column is being added, dropped or renamed with no data loss. 
-- It acquires minimal locks through out the process (read more below on the caveat).
+## Prominent features
+- `pg-osc` supports when a column is being added, dropped or renamed with no data loss. 
+- `pg-osc` acquires minimal locks throughout the process (read more below on the caveats).
 - Copies over indexes and Foreign keys.
 - Optionally drop or retain old tables in the end.
-- **TBD**: It supports the ability to reverse the change with no data loss. pgosc makes sure that the data is being replayed in both directions (tables) before and after the swap. So in case of any issues, you can always go back to the original table.
+- Backfill old/new columns as data is copied from primary table to shadow table, and then perform the swap. [Example](#Backfill-data-and-run-alter-statements)
+- **TBD**: Ability to reverse the change with no data loss. [tracking issue](https://github.com/shayonj/pg-online-schema-change/issues/14)
 
-### Caveats / Limitations
-- A primary key should exists on the table, without it pgosc will error out early.
-  - This is because - currently there is no other way to uniquely identify rows during replay.
-- For a brief moment, towards the end of the process pgosc will acquire a `ACCESS EXCLUSIVE lock` to perform the swap of table name and FK references.
-- By design it doesn't kill any other DDLs being performed. Its best to not run any DDLs against parent table during the process to avoid any issues.
-- During the nature of duplicating a table, there needs to be enough space on the disk to support the operation.
+## Examples
+
+### Renaming a column
+```
+pg-online-schema-change perform \
+  --alter-statement 'ALTER TABLE books RENAME COLUMN email TO new_email' \
+  --dbname "postgres" \
+  --host "localhost" \
+  --username "jamesbond" \
+  --password "" \
+```
+
+### Multiple ALTER statements
+```
+pg-online-schema-change perform \
+  --alter-statement 'ALTER TABLE books ADD COLUMN "purchased" BOOLEAN DEFAULT FALSE; ALTER TABLE books RENAME COLUMN email TO new_email;' \
+  --dbname "postgres" \
+  --host "localhost" \
+  --username "jamesbond" \
+  --password "" \
+  --drop
+```
+
+### Kill other backends after 5s
+If the operation is being performed on a busy table, you can use `pg-osc`'s `kill-backend` functionality to kill other backends that may be competing with the `pg-osc` operation to acquire a lock for a brief while. The `ACCESS EXCLUSIVE` lock acquired by `pg-osc` is only for a brief while and released after. You can tune how long `pg-osc` should wait before killing other backends (or if at all `pg-osc` should kill backends in the first place).
+
+```
+pg-online-schema-change perform \
+  --alter-statement 'ALTER TABLE books ADD COLUMN "purchased" BOOLEAN DEFAULT FALSE;' \
+  --dbname "postgres" \
+  --host "localhost" \
+  --username "jamesbond" \
+  --password "" \
+  --wait-time-for-lock=5 \
+  --kill-backends \
+  --drop
+```
+### Backfill data
+When inserting data into the shadow table, instead of just copying all columns and rows from the primary table, you can pass in a custom sql file to perform the copy and do any additional work. For instance - backfilling certain columns. By providing the `copy-statement`, `pg-osc` will instead play the query to perform the copy operation.
+
+**IMPORTANT NOTES:**
+- It is possible to violate a constraint accidentally or not copy data, **so proceed with caution**.
+- The `ALTER` statement can change the table's structure, **so proceed with caution**.
+- Preserve `%{shadow_table}` as that will be replaced with the destination of the shadow table.
+
+```sql
+-- file: /src/query.sql
+INSERT INTO %{shadow_table}(foo, bar, baz, rental_id, tenant_id)
+SELECT a.foo,a.bar,a.baz,a.rental_id,r.tenant_id AS tenant_id
+FROM ONLY examples a
+LEFT OUTER JOIN rentals r
+ON a.rental_id = r.id
+```
+
+```
+pg-online-schema-change perform \
+  --alter-statement 'ALTER TABLE books ADD COLUMN "tenant_id" VARCHAR;' \
+  --dbname "postgres" \
+  --host "localhost" \
+  --username "jamesbond" \
+  --password "" \
+  --copy-statement "/src/query.sql" \
+  --drop
+```
+### Caveats
+- A primary key should exist on the table; without it, `pg-osc` will raise an exception
+	- This is because - currently there is no other way to uniquely identify rows during replay.
+- `pg-osc` will acquire `ACCESS EXCLUSIVE` lock on the parent table twice during the.
+	- First, when setting up the triggers and the shadow table.
+	- Next, when performing the swap and updating FK references
+	- Note: If `kill-backends` is passed, it will attempt to terminate any competing operations during both times. 
+- By design, `pg-osc` doesn't kill any other DDLs being performed. It's best to not run any DDLs against the parent table during the operation.
+- Due to the nature of duplicating a table, there needs to be enough space on the disk to support the operation.
 - Index, constraints and sequence names will be altered and lose their original naming.
-  - Can be fixed in future releases. Feel free to open a feature req.
+	- Can be fixed in future releases. Feel free to open a feature req.
 - Triggers are not carried over. 
-  - Can be fixed in future releases. Feel free to open a feature req.
-- Foreign keys are dropped & re-added to referencing tables with a NOT VALID.
-  - This is to ensure that integrity is maintained as before but skip the FK validation to avoid long locks.
+- Can be fixed in future releases. Feel free to open a feature req.
+- Foreign keys are dropped & re-added to referencing tables with a `NOT VALID`. A follow on `VALIDATE CONSTRAINT` is run.
+ 	- Ensures that integrity is maintained and re-introducing FKs doesn't acquire additional locks, hence the `NOT VALID`.
 ## Development
 
 - Install ruby 3.0
@@ -109,7 +180,7 @@ rvm use 3.0.0
 - Then, run `bundle exec spec` to run the tests. 
 - You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. 
 
 ## Contributing
 

--- a/lib/pg_online_schema_change/cli.rb
+++ b/lib/pg_online_schema_change/cli.rb
@@ -16,9 +16,11 @@ module PgOnlineSchemaChange
     method_option :drop, aliases: "-f", type: :boolean, default: false,
                          desc: "Drop the original table in the end after the swap"
     method_option :kill_backends, aliases: "-k", type: :boolean, default: false,
-                                  desc: "Kill other competing queries/backends when trying to acquire lock for the swap. It will wait for --wait-time-for-lock duration before killing backends and try upto 3 times."
+                                  desc: "Kill other competing queries/backends when trying to acquire lock for the shadow table creation and swap. It will wait for --wait-time-for-lock duration before killing backends and try upto 3 times."
     method_option :wait_time_for_lock, aliases: "-w", type: :numeric, default: 10,
                                        desc: "Time to wait before killing backends to acquire lock and/or retrying upto 3 times. It will kill backends if --kill-backends is true, otherwise try upto 3 times and exit if it cannot acquire a lock."
+    method_option :copy_statement, aliases: "-c", type: :string, required: false,
+                                   desc: "Takes a .sql file location where you can provide a custom query to be played (ex: backfills) when pgosc copies data from the primary to the shadow table. More examples in README."
 
     def perform
       client_options = Struct.new(*options.keys.map(&:to_sym)).new(*options.values)

--- a/lib/pg_online_schema_change/helper.rb
+++ b/lib/pg_online_schema_change/helper.rb
@@ -7,6 +7,10 @@ module PgOnlineSchemaChange
       Store.set(:primary_key, Query.primary_key_for(client, client.table))
     end
 
+    def logger
+      PgOnlineSchemaChange.logger
+    end
+
     def method_missing(method, *_args)
       result = Store.send(:get, method)
       return result if result

--- a/lib/pg_online_schema_change/replay.rb
+++ b/lib/pg_online_schema_change/replay.rb
@@ -35,7 +35,7 @@ module PgOnlineSchemaChange
       end
 
       def play!(rows, reuse_trasaction = false)
-        PgOnlineSchemaChange.logger.info("Replaying rows, count: #{rows.size}")
+        logger.info("Replaying rows, count: #{rows.size}")
 
         to_be_deleted_rows = []
         to_be_replayed = []

--- a/spec/fixtures/copy.sql
+++ b/spec/fixtures/copy.sql
@@ -1,0 +1,3 @@
+INSERT INTO %{shadow_table} ("username", "seller_id", "password", "email", "createdOn", "last_login", "user_id")
+SELECT "username", "seller_id", "password", "email", "createdOn", "last_login", "user_id"
+FROM ONLY books

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -15,6 +15,7 @@ module DatabaseHelpers
       drop: false,
       kill_backends: false,
       wait_time_for_lock: 5,
+      copy_statement: "",
     }
     Struct.new(*options.keys).new(*options.values)
   end


### PR DESCRIPTION
This allows users to pass a custom sql file that will be played
when copying data from primary to shadow table.

Users will have full control over the operation and pg-osc
will just play the contents of the file. It takes in an optional
--copy-statement flag with the location of the sql file. There
is a template var that points to shadow_table which is replaced
when the query is being perform. This way users can customize
the 'INSER INTO' statement as well.

This is an advanced feature. There are some good uses like backfilling
that can be performed with this. h/t to Jeff Frost (@jfrost) for this idea.

Freshened the README and added some examples

Fixes: https://github.com/shayonj/pg-online-schema-change/issues/30
cc/fyi @jfrost