### PR TITLE
Set statement_timeout for swap to 5s

### DIFF
--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -734,6 +734,10 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
 
     it "closes transaction when it couldn't acquire lock" do
       expect(PgOnlineSchemaChange::Query).to receive(:get_foreign_keys_to_refresh).with(client, client.table)
+      expect(PgOnlineSchemaChange::Query).to receive(:run).with(
+        client.connection,
+        "SET statement_timeout = 0;",
+      ).once.and_call_original
       expect(PgOnlineSchemaChange::Query).to receive(:run).with(client.connection, "COMMIT;").once.and_call_original
       expect(PgOnlineSchemaChange::Query).to receive(:open_lock_exclusive).and_raise(PgOnlineSchemaChange::AccessExclusiveLockNotAcquired)
 


### PR DESCRIPTION
This is mostly proofing against any cases
where drop constraint goes into a lock queue
and the transaction sits idle/handing while have
acquired access exclusive lock on the primary table.
In such a case the transaction will rollback and program
will end (with cleanup).