### PR TITLE
Ensure there is a default value for copy_statement

### DIFF
--- a/lib/pg_online_schema_change/cli.rb
+++ b/lib/pg_online_schema_change/cli.rb
@@ -19,7 +19,7 @@ module PgOnlineSchemaChange
                                   desc: "Kill other competing queries/backends when trying to acquire lock for the shadow table creation and swap. It will wait for --wait-time-for-lock duration before killing backends and try upto 3 times."
     method_option :wait_time_for_lock, aliases: "-w", type: :numeric, default: 10,
                                        desc: "Time to wait before killing backends to acquire lock and/or retrying upto 3 times. It will kill backends if --kill-backends is true, otherwise try upto 3 times and exit if it cannot acquire a lock."
-    method_option :copy_statement, aliases: "-c", type: :string, required: false,
+    method_option :copy_statement, aliases: "-c", type: :string, required: false, default: "",
                                    desc: "Takes a .sql file location where you can provide a custom query to be played (ex: backfills) when pgosc copies data from the primary to the shadow table. More examples in README."
 
     def perform


### PR DESCRIPTION
This is to ensure the Struct build up doesn't fail
and also non required feels have defaults for better validations