### PR TITLE
Preserve constraint names on the shadow table

### DIFF
--- a/lib/pg_online_schema_change/functions.rb
+++ b/lib/pg_online_schema_change/functions.rb
@@ -54,7 +54,7 @@ FUNC_CREATE_TABLE_ALL = <<~SQL.freeze
       EXECUTE format(
               'ALTER TABLE %s add constraint %s %s',
               newsource_table,
-              replace(rec.conname, source_table, newsource_table),
+              rec.conname,
               pg_get_constraintdef(rec.oid));
       END LOOP;
     END

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
                                                                       described_class.shadow_table.to_s)
       expect(foreign_keys).to eq([
                                    { "table_on" => described_class.shadow_table.to_s, "table_from" => "sellers",
-                                     "constraint_type" => "f", "constraint_name" => "#{described_class.shadow_table}_seller_id_fkey", "constraint_validated" => "t", "definition" => "FOREIGN KEY (seller_id) REFERENCES sellers(id)" },
+                                     "constraint_type" => "f", "constraint_name" => "#{client.table}_seller_id_fkey", "constraint_validated" => "t", "definition" => "FOREIGN KEY (seller_id) REFERENCES sellers(id)" },
                                  ])
       primary_keys = PgOnlineSchemaChange::Query.get_primary_keys_for(client,
                                                                       described_class.shadow_table.to_s)


### PR DESCRIPTION
There is no need to rename/replace constraint name here, since
these are localized to the table (shadow table). Replacing logic
isn't fully tested and results in edge cases where replacing substring
that matches table name and shadow table name ends up with longer constraint
name if you run pg-osc multiple times on a table. This keeps it simple and consistent
at all times